### PR TITLE
Additional if condition for header.examples

### DIFF
--- a/templates/default.md
+++ b/templates/default.md
@@ -35,7 +35,7 @@
 <% }); //forech parameter -%>
 <% } //if parameters -%>
 
-<% if (data[group][sub][0].header && data[group][sub][0].header.examples.length) { -%>
+<% if (data[group][sub][0].header && data[group][sub][0].header.examples && data[group][sub][0].header.examples.length) { -%>
 
 ### Header Examples
 


### PR DESCRIPTION
Additional if condition for header.examples, prevents from an error querying the length of header.examples. Should resolve #5 